### PR TITLE
Added an optional key to project map of template additions.

### DIFF
--- a/src/leiningen/create_template.clj
+++ b/src/leiningen/create_template.clj
@@ -48,6 +48,7 @@
               (concat
                 (:source-files info)
                 (:test-files info)
+                (:template-additions info)
                 [(:project-file info)]))
          true)))
 
@@ -56,6 +57,7 @@
          (:source-files info)
          (:test-files info)
          (:java-files info)
+         (:template-additions info)
          [(:project-file info)])))
 
 (defn walk [^File dir]
@@ -101,7 +103,7 @@
      :old-project-name (:name project)
      :new-project-name (first args)
      :project-file (jio/as-file (str root-path "/project.clj"))
-     :source-files (get-files-recusivly (:source-paths project))
+     :template-additions (for [f (:template-additions project)] (jio/as-file f))
      :resource-files (get-files-recusivly (:resource-paths project))
      :java-files (get-files-recusivly (:java-source-paths project))
      :test-files (get-files-recusivly (:test-paths project))}))


### PR DESCRIPTION
:template-additions followed by a seq is useful for adding non-standard files to a project template, i.e. project-header.clj in jig profiles.clj, README, etc.
