### PR TITLE
Make template-additions more accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin requires Leiningen 2.0+
 
 Add to ~/.lein/profiles.clj:
 
-    {:user {:plugins [[lein-create-template "0.1.1"]]}}
+    {:user {:plugins [[lein-create-template "0.1.2"]]}}
 
 ## Usage
 
@@ -21,6 +21,22 @@ The command will create a folder on the root of your Leiningen project.
 The folder will be assigned the new template name you provided
 and will contain a Leiningen template project of your skeleton project.
 
+(NOTE: Make sure that the directories of your skeleton project are
+clean of any extraneous files (e.g. editor temp files). Otherwise,
+these files will be dragged along into your template. Also, note that
+many common tools hide .gitignore'd files and make it easy to overlook
+some of these extra files. So, it is a good idea to build the template
+from a clean clone of the skeleton, or carefully remove all
+temp/output files.)
+
+The template will automatically include the source files, test files,
+and project.clj of your skeleton project. If you want to include other
+files too, you can specify them by adding a :template-additions clause
+to your project.clj, e.g.:
+
+    :template-additions [".gitignore" "README.md"]
+
+
 Move the template project folder to the destination of choice.
 At the root of your new template project execute the following command.
 
@@ -29,6 +45,14 @@ At the root of your new template project execute the following command.
 You can now use your new template by executing
 
     $ lein new <you new template name> <your new project name>
+
+
+WARNING: If your project is a *-SNAPSHOT version, you may get the
+error 'Failed to resolve version for :lein-template:jar:RELEASE'.  A
+workaround for this problem seems to be to run the 'lein new' command
+while within the directory of the template project. I don't understand
+why this works; see the discussion referenced in [this
+issue](https://github.com/tcw/lein-create-template/issues/2).
 
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-create-template "0.1.1"
+(defproject lein-create-template "0.1.2"
   :description "A Leiningen plugin for creating templates from existing skeleton projects"
   :url "http://github.com/tcw/lein-create-template"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/create_template.clj
+++ b/src/leiningen/create_template.clj
@@ -103,6 +103,7 @@
      :old-project-name (:name project)
      :new-project-name (first args)
      :project-file (jio/as-file (str root-path "/project.clj"))
+     :source-files (get-files-recusivly (:source-paths project))
      :template-additions (for [f (:template-additions project)] (jio/as-file f))
      :resource-files (get-files-recusivly (:resource-paths project))
      :java-files (get-files-recusivly (:java-source-paths project))


### PR DESCRIPTION
Bump the project version and add some info to the README.md so the template-additions enhancement of a few months ago is more readily available.

Also, replace a line that seems to have been accidentally deleted last year. Without it, no source files are collected.

If this pull request is accepted, please also push to clojars.